### PR TITLE
Fix login workflow and JS

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -43,7 +43,7 @@ def fonts(filename):
 
 @route("/login")
 def login():
-    return template("login")
+    return template("login", sucesso=True)
 
 
 def check_login(username, password):
@@ -55,7 +55,7 @@ def check_login(username, password):
 
 @route("/")
 def index():
-    return template("login")
+    return template("login", sucesso=True)
 
 
 @route("/", method="POST")
@@ -63,7 +63,7 @@ def acao_login():
     username = request.forms.get("username")
     password = request.forms.get("password")
     sucesso = check_login(username, password)
-    return template("verificacao_login", sucesso=check_login(username, password))
+    return template("verificacao_login", sucesso=sucesso, name=username)
 
 
 @error(404)

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -1,11 +1,6 @@
-$(document).ready(function() {
-  $(document).mousemove(function(e){
-    TweenLite.to$(body),
-    .5,
-    {css:
-      {
-        backgroundPosition: "" + parseInt(event.pageX/8)
-      }
-    }
-  }
-}
+$(document).ready(function () {
+  $(document).mousemove(function (e) {
+    const offsetX = parseInt(e.pageX / 8);
+    $('body').css('background-position', `${offsetX}px 0`);
+  });
+});


### PR DESCRIPTION
## Summary
- fix login template rendering by passing initial `sucesso` state
- send username to verification template and avoid duplicate password checks
- replace corrupted `login.js` with working jQuery code

## Testing
- `python -m py_compile __init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848cd60d9108329b411dc3261f61075